### PR TITLE
feat: add reusable icon component

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,4 +1,5 @@
 ---
+import Icon from '@/components/Icon.astro';
 import type { NavLink } from '@/data/navigation';
 import { primaryNav } from '@/data/navigation';
 
@@ -63,9 +64,7 @@ const isActive = (link: NavLink) => {
       class="inline-flex h-11 w-11 items-center justify-center rounded-full border border-brand-border/80 text-brand-ink transition hover:border-brand-primary hover:text-brand-primary focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-accent md:hidden"
       aria-label="Open navigation"
     >
-      <svg class="h-5 w-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
-        <path d="M4 7h16M4 12h16M4 17h16" stroke-linecap="round" />
-      </svg>
+      <Icon name="menu" size={20} />
     </button>
   </div>
 </header>

--- a/src/components/Icon.astro
+++ b/src/components/Icon.astro
@@ -1,0 +1,63 @@
+---
+import ArrowBack from '@/icons/arrow-back.svg?component';
+import ArrowDown from '@/icons/arrow-down.svg?component';
+import ArrowForward from '@/icons/arrow-forward.svg?component';
+import ArrowUp from '@/icons/arrow-up.svg?component';
+import Close from '@/icons/close.svg?component';
+import Menu from '@/icons/menu.svg?component';
+import Play from '@/icons/play.svg?component';
+
+type IconComponent = typeof ArrowBack;
+
+const iconMap = {
+  'arrow-back': ArrowBack,
+  'arrow-forward': ArrowForward,
+  'arrow-down': ArrowDown,
+  'arrow-up': ArrowUp,
+  close: Close,
+  menu: Menu,
+  play: Play,
+} satisfies Record<string, IconComponent>;
+
+const aliases = {
+  'arrow-left': 'arrow-back',
+  'arrow-right': 'arrow-forward',
+  'chevron-left': 'arrow-back',
+  'chevron-right': 'arrow-forward',
+  'chevron-down': 'arrow-down',
+  'chevron-up': 'arrow-up',
+} as const;
+
+type IconName = keyof typeof iconMap | keyof typeof aliases;
+
+interface Props {
+  name: IconName;
+  size?: number | string;
+  class?: string;
+  title?: string;
+}
+
+const {
+  name,
+  size = 20,
+  class: className = '',
+  title,
+} = Astro.props as Props;
+
+const resolvedName = (name in aliases ? aliases[name as keyof typeof aliases] : name) as keyof typeof iconMap;
+const Component = iconMap[resolvedName];
+
+if (!Component) {
+  throw new Error(`Icon \\"${name}\\" is not available.`);
+}
+
+const resolvedSize = typeof size === 'number' ? `${size}px` : size;
+const ariaProps = title
+  ? ({ role: 'img', 'aria-label': title } as const)
+  : ({ role: 'presentation', 'aria-hidden': 'true' } as const);
+---
+<Component
+  class:list={["inline-block", className]}
+  style={`width: ${resolvedSize}; height: ${resolvedSize};`}
+  {...ariaProps}
+/>

--- a/src/icons/arrow-back.svg
+++ b/src/icons/arrow-back.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M19 12H5" />
+  <path d="M11 6l-6 6 6 6" />
+</svg>

--- a/src/icons/arrow-down.svg
+++ b/src/icons/arrow-down.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M12 5v14" />
+  <path d="M6 13l6 6 6-6" />
+</svg>

--- a/src/icons/arrow-forward.svg
+++ b/src/icons/arrow-forward.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M5 12h14" />
+  <path d="M13 6l6 6-6 6" />
+</svg>

--- a/src/icons/arrow-up.svg
+++ b/src/icons/arrow-up.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M12 19V5" />
+  <path d="M18 11l-6-6-6 6" />
+</svg>

--- a/src/icons/close.svg
+++ b/src/icons/close.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M6 6l12 12" />
+  <path d="M18 6L6 18" />
+</svg>

--- a/src/icons/menu.svg
+++ b/src/icons/menu.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M4 7h16" />
+  <path d="M4 12h16" />
+  <path d="M4 17h16" />
+</svg>

--- a/src/icons/play.svg
+++ b/src/icons/play.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" stroke="currentColor" stroke-width="1.2" stroke-linejoin="round">
+  <path d="M9 7l8 5-8 5V7z" />
+</svg>

--- a/tasklist.md
+++ b/tasklist.md
@@ -30,10 +30,10 @@
 
 ## Phase 3 — Icons
 
-* [ ] Identify used icons in `/legacy` (Ionicons, etc.).
-* [ ] Extract to inline SVGs under `src/icons/**`.
-* [ ] Build `src/components/Icon.astro` that renders an SVG by `{name}` with `{size}`, `{class}`, `{title}`.
-* [ ] Replace icon font references with `<Icon name="..." />`.
+* [x] Identify used icons in `/legacy` (Ionicons, etc.).
+* [x] Extract to inline SVGs under `src/icons/**`.
+* [x] Build `src/components/Icon.astro` that renders an SVG by `{name}` with `{size}`, `{class}`, `{title}`.
+* [x] Replace icon font references with `<Icon name="..." />`.
 
 ## Phase 4 — Optimized images (astro:assets)
 


### PR DESCRIPTION
## Summary
- add inline SVG assets for frequently used arrows, menu, close, and play icons
- create a reusable `<Icon>` component with size, alias, and accessibility options
- switch the header hamburger button to use the new icon component and mark the icon phase complete in the task list

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68db9daac1ac8324959f47cc1043a167