### PR TITLE
Implement Phase 4 astro assets pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules
+dist
 .dist
 .astro
 .DS_Store

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,17 +1,21 @@
 ---
 import { contactEmail, footerNav, primaryNav } from '@/data/navigation';
+import Logo from './Logo.astro';
 
 const year = new Date().getFullYear();
 ---
 <footer class="bg-brand-ink text-white">
   <div class="mx-auto w-full max-w-6xl px-5 py-16 sm:px-6 lg:px-8">
     <div class="flex flex-col gap-12 md:flex-row md:justify-between">
-      <div class="max-w-xl space-y-4">
-        <p class="text-xs font-semibold uppercase tracking-[0.32em] text-brand-accent">Creative Momentum</p>
-        <h2 class="text-3xl font-semibold uppercase tracking-tight text-white md:text-4xl">Where design, story, and tech align.</h2>
-        <p class="text-sm leading-relaxed text-white/70">
-          Phase two lays the groundwork for the refreshed Dsynhub experience—brand colors, typography, and layout scaffolding that will support every upcoming page build.
-        </p>
+      <div class="max-w-xl space-y-6">
+        <Logo variant="light" class="h-12" />
+        <div class="space-y-4">
+          <p class="text-xs font-semibold uppercase tracking-[0.32em] text-brand-accent">Creative Momentum</p>
+          <h2 class="text-3xl font-semibold uppercase tracking-tight text-white md:text-4xl">Where design, story, and tech align.</h2>
+          <p class="text-sm leading-relaxed text-white/70">
+            Phase two lays the groundwork for the refreshed Dsynhub experience—brand colors, typography, and layout scaffolding that will support every upcoming page build.
+          </p>
+        </div>
       </div>
       <div class="grid gap-10 text-sm uppercase tracking-[0.24em] text-white/70 sm:grid-cols-2 md:text-xs">
         <div>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,6 +1,7 @@
 ---
 import type { NavLink } from '@/data/navigation';
 import { primaryNav } from '@/data/navigation';
+import Logo from './Logo.astro';
 
 interface Props {
   currentPath: string;
@@ -18,10 +19,8 @@ const isActive = (link: NavLink) => {
 ---
 <header class="sticky top-0 z-40 border-b border-brand-border/60 bg-white/85 backdrop-blur">
   <div class="mx-auto flex w-full max-w-6xl items-center justify-between gap-4 px-5 py-4 sm:px-6 lg:px-8">
-    <a href="/" class="group flex items-center gap-3">
-      <span class="flex h-11 w-11 items-center justify-center rounded-full border border-brand-border/80 text-sm font-bold uppercase tracking-[0.32em] text-brand-ink transition hover:border-brand-primary hover:text-brand-primary">
-        DH
-      </span>
+    <a href="/" class="group flex items-center gap-4">
+      <Logo class="h-11 transition group-hover:drop-shadow" />
       <span class="hidden flex-col text-xs font-medium uppercase leading-tight tracking-[0.28em] text-brand-muted sm:flex">
         <span class="text-brand-primary">Dsynhub</span>
         <span>Codex</span>

--- a/src/components/Logo.astro
+++ b/src/components/Logo.astro
@@ -1,0 +1,32 @@
+---
+import { Image } from 'astro:assets';
+import logoDark from '@/assets/img/logo-blck.png';
+import logoLight from '@/assets/img/logo-white.png';
+
+interface Props {
+  variant?: 'dark' | 'light';
+  class?: string;
+  title?: string;
+}
+
+const {
+  variant = 'dark',
+  class: className = '',
+  title = 'Dsynhub Codex logo',
+} = Astro.props as Props & { class?: string };
+
+const src = variant === 'light' ? logoLight : logoDark;
+---
+<span class={`inline-flex items-center ${className}`.trim()}>
+  <Image
+    src={src}
+    alt="Dsynhub Codex"
+    widths={[160, 200, 268]}
+    sizes="(max-width: 768px) 160px, 200px"
+    formats={['avif', 'webp', 'png']}
+    loading="eager"
+    decoding="async"
+    class="h-full w-auto"
+    title={title}
+  />
+</span>

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -3,17 +3,30 @@ import Footer from '@/components/Footer.astro';
 import Header from '@/components/Header.astro';
 import '@/styles/main.css';
 
+type LayoutVariant = 'default' | 'legacy-parallax';
+
 interface Props {
   title?: string;
   description?: string;
+  variant?: LayoutVariant;
 }
 
-const { title = 'Dsynhub Codex', description = 'Astro + Tailwind rebuild guided by the legacy Struktur theme.' } =
-  Astro.props as Props;
+const {
+  title = 'Dsynhub Codex',
+  description = 'Astro + Tailwind rebuild guided by the legacy Struktur theme.',
+  variant = 'default',
+} = Astro.props as Props;
 
 const currentPath = Astro.url.pathname;
+
+const showChrome = variant === 'default';
+const htmlClass = variant === 'legacy-parallax' ? 'bg-white text-brand-ink' : 'bg-brand-surface text-brand-ink';
+const bodyClass =
+  variant === 'legacy-parallax'
+    ? 'flex min-h-screen flex-col bg-white text-brand-ink'
+    : 'flex min-h-screen flex-col bg-brand-surface text-brand-ink';
 ---
-<html lang="en" class="bg-brand-surface text-brand-ink">
+<html lang="en" class={htmlClass}>
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -23,12 +36,12 @@ const currentPath = Astro.url.pathname;
     <link rel="preload" href="/fonts/roboto-700.woff2" as="font" type="font/woff2" crossorigin />
     <slot name="head" />
   </head>
-  <body class="flex min-h-screen flex-col bg-brand-surface text-brand-ink">
+  <body class={bodyClass}>
     <a class="skip-link" href="#main-content">Skip to main content</a>
-    <Header currentPath={currentPath} />
+    {showChrome && <Header currentPath={currentPath} />}
     <main id="main-content" class="flex-1">
       <slot />
     </main>
-    <Footer />
+    {showChrome && <Footer />}
   </body>
 </html>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,27 +1,98 @@
 ---
 import BaseLayout from '@/layouts/Base.astro';
+import heroOne from '@/assets/img/home-4-image-1.jpg';
+import heroTwo from '@/assets/img/home-4-image-2.jpg';
+import heroThree from '@/assets/img/home-4-image-3.jpg';
+import heroFour from '@/assets/img/home-4-image-4.jpg';
+import heroFive from '@/assets/img/home-4-image-5.jpg';
+
+const sections = [
+  {
+    id: 'branding',
+    title: 'Branding',
+    categories: ['Editorial', 'Typography', 'Website'],
+    image: heroOne,
+  },
+  {
+    id: 'fashion-photography',
+    title: 'Fashion Photography',
+    categories: ['Editorial', 'Typography', 'Website'],
+    image: heroTwo,
+  },
+  {
+    id: 'see-our-products',
+    title: 'See Our Products',
+    categories: ['Editorial', 'Typography', 'Website'],
+    image: heroThree,
+  },
+  {
+    id: 'app-and-digital',
+    title: 'App & Digital',
+    categories: ['Editorial', 'Typography', 'Website'],
+    image: heroFour,
+  },
+  {
+    id: 'branding-inspiration',
+    title: 'Branding Inspiration',
+    categories: ['Editorial', 'Typography', 'Website'],
+    image: heroFive,
+  },
+];
 ---
-<BaseLayout title="Dsynhub Codex" description="Design system foundation for the Struktur to Astro rebuild.">
-  <section class="mx-auto flex w-full max-w-4xl flex-col gap-8 px-5 py-24 sm:px-6 lg:px-8">
-    <p class="text-xs font-semibold uppercase tracking-[0.32em] text-brand-primary">Phase 2 &middot; Design System</p>
-    <div class="space-y-6">
-      <h1 class="text-4xl font-semibold uppercase leading-tight tracking-tight text-brand-ink sm:text-5xl">
-        Crafting the visual language for every upcoming page.
-      </h1>
-      <p class="text-base leading-relaxed text-brand-muted md:text-lg">
-        Tailwind tokens, self-hosted typography, and a reusable layout shell are now in place.
-        This foundation mirrors the Struktur palette while giving us modern controls for building the new Dsynhub experience in Astro.
-      </p>
-      <div class="flex flex-wrap items-center gap-4 pt-4 text-xs uppercase tracking-[0.28em] text-brand-muted">
-        <span class="inline-flex items-center gap-2 rounded-full border border-brand-border/60 px-4 py-2">
-          <span class="h-2 w-2 rounded-full bg-brand-primary" aria-hidden="true" />
-          Roboto &middot; 400 / 700
-        </span>
-        <span class="inline-flex items-center gap-2 rounded-full border border-brand-border/60 px-4 py-2">
-          <span class="h-2 w-2 rounded-full bg-brand-accent" aria-hidden="true" />
-          Palette synced from Struktur
-        </span>
-      </div>
+<BaseLayout
+  title="Parallax Showcase – Struktur"
+  description="A faithful Tailwind CSS recreation of the Struktur Parallax Showcase."
+  variant="legacy-parallax"
+>
+  <div id="top" class="relative">
+    <header class="pointer-events-none fixed top-0 left-0 right-0 z-20 flex items-center justify-between px-6 py-8 text-white sm:px-10 lg:px-16">
+      <a
+        href="#top"
+        class="pointer-events-auto text-sm font-semibold uppercase tracking-[0.6em] text-white transition hover:opacity-80"
+      >
+        Struktur.
+      </a>
+      <button
+        type="button"
+        class="pointer-events-auto inline-flex h-10 w-10 items-center justify-center rounded-full border border-white/40 transition hover:border-white hover:bg-white/10"
+        aria-label="Open navigation"
+      >
+        <span class="h-1.5 w-1.5 rounded-full bg-white" aria-hidden="true" />
+      </button>
+    </header>
+
+    <nav class="pointer-events-none fixed bottom-16 right-6 z-20 origin-bottom-right -rotate-90 text-[0.65rem] font-semibold uppercase tracking-[0.6em] text-[#e84945] sm:right-10 lg:right-16">
+      <a href="#top" class="pointer-events-auto transition hover:text-white">Back to top</a>
+    </nav>
+
+    <div class="space-y-0">
+      {sections.map((section) => (
+        <section
+          id={section.id}
+          class="relative flex min-h-screen items-stretch justify-center overflow-hidden bg-black text-white"
+        >
+          <div
+            class="absolute inset-0 bg-cover bg-center bg-no-repeat md:bg-fixed"
+            style={{ backgroundImage: `url(${section.image.src})` }}
+            aria-hidden="true"
+          />
+          <div class="absolute inset-0 bg-black/40" aria-hidden="true" />
+
+          <div class="relative z-10 flex w-full max-w-6xl flex-col justify-center gap-10 px-6 py-24 sm:px-10 sm:py-32 lg:px-16">
+            <div class="space-y-6">
+              <h2 class="text-[2.75rem] font-bold uppercase leading-none tracking-tight sm:text-[4rem] lg:text-[5.625rem]">
+                {section.title}
+              </h2>
+              <div class="flex flex-wrap items-center gap-3 text-xs font-semibold uppercase tracking-[0.45em] sm:text-sm">
+                <span class="h-px w-16 bg-white" aria-hidden="true" />
+                <span class="whitespace-nowrap">
+                  {section.categories.join(' / ')}
+                </span>
+              </div>
+            </div>
+          </div>
+        </section>
+      ))}
     </div>
-  </section>
+  </div>
 </BaseLayout>


### PR DESCRIPTION
## Summary
- add a reusable Logo component that serves optimized variants through `astro:assets`
- rebuild the home page to match the legacy parallax showcase design using Tailwind-only full-screen sections and overlay navigation
- extend the base layout with a chrome-free variant so the parallax homepage renders without the standard header/footer while leaving other routes unchanged

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dba5f578b0832498c8d0bbd444ed32